### PR TITLE
Add options for HPSW using TMC2209 board

### DIFF
--- a/Firmware Changes.txt
+++ b/Firmware Changes.txt
@@ -5,6 +5,9 @@ myFP2ESP Focus Controller [ESP8266/ESP32]
 (c) Copyright Paul P, 2021. All Rights Reserved.
 ==============================================================
 
+228
+// Fix for home position code on TMC2209 board
+
 227
 // Add PHYSICALHPSW option to TMC2209 board as an alternative to STALLGUARD
 // Fix errors in checking DRV combinations which flag errors (focuserconfig.h)

--- a/src/myFP2ESP/ManagementServer.cpp
+++ b/src/myFP2ESP/ManagementServer.cpp
@@ -1519,7 +1519,7 @@ void MANAGEMENT_handleadminpg2(void)
       if ( mySetupData->get_hpswitchenable() == 0)
       {
         mySetupData->set_hpswitchenable(1);
-        if ( driverboard->init_homepositionswitch() == true)
+        if ( driverboard->init_hpsw() == true)
         {
           MSrvr_DebugPrintln("hpsw init OK");
         }
@@ -2388,7 +2388,7 @@ void MANAGEMENT_handleset(void)
       if ( value == "on" )
       {
         mySetupData->set_hpswitchenable(1);
-        if ( driverboard->init_homepositionswitch() == true)
+        if ( driverboard->init_hpsw() == true)
         {
           MSrvr_DebugPrintln("hpsw init OK");
         }

--- a/src/myFP2ESP/comms.h
+++ b/src/myFP2ESP/comms.h
@@ -522,9 +522,9 @@ void ESP_Communication()
       SendPaket('L', mySetupData->get_oledupdateonmove());
       break;
     case 63: // get status of home position switch (hpsw pin 1=open, 0=closed)
-      if ( mySetupData->get_hpswitchenable() == 1)
+      if ( mySetupData->get_hpswitchenable() == 1)    // if the hpsw is enabled
       {
-        SendPaket('H', !digitalRead(mySetupData->get_brdhpswpin()));    // return 1 if closed, 0 if open
+        SendPaket('H', driverboard->hpsw_alert());    // get state of hpsw, return 1 if closed, 0 if open
       }
       else
       {
@@ -833,7 +833,7 @@ void ESP_Communication()
           if ( enablestate == 1 )
           {
             Comms_DebugPrintln("hpsw state: enabled");
-            if ( driverboard->init_homepositionswitch() == true)
+            if ( driverboard->init_hpsw() == true)
             {
               Comms_DebugPrintln("hpsw init OK");
             }

--- a/src/myFP2ESP/focuserconfig.h
+++ b/src/myFP2ESP/focuserconfig.h
@@ -32,7 +32,7 @@
 //#define DRVBRD 	PRO2EL9110S
 //#define DRVBRD 	CUSTOMBRD
 // ESP32 Boards
-#define DRVBRD 	PRO2ESP32DRV8825
+//#define DRVBRD 	PRO2ESP32DRV8825
 //#define DRVBRD 	PRO2ESP32ULN2003
 //#define DRVBRD 	PRO2ESP32L298N
 //#define DRVBRD 	PRO2ESP32L293DMINI
@@ -40,7 +40,7 @@
 //#define DRVBRD 	PRO2ESP32R3WEMOS
 //#define DRVBRD  PRO2ESP32TMC2225
 //#define DRVBRD  PRO2ESP32TMC2209
-//#define DRVBRD  PRO2ESP32TMC2209P              // this is for Paul using TMC2209 - 58.jsn
+#define DRVBRD  PRO2ESP32TMC2209P              // this is for Paul using TMC2209 - 58.jsn
 //#define DRVBRD  PRO2ESP32ST6128                // This is board for CLOSED LOOP ST6128 driver
 //#define DRVBRD 	CUSTOMBRD
 
@@ -170,7 +170,7 @@
 // If using STALLGUARD or HOMEPOSITIONSWITCH, uncomment one of the following (not both)
 //#define USE_STALL_GUARD 1
 
-//#define USE_PHYSICAL_SWITCH 2
+#define USE_PHYSICAL_SWITCH 2
 // A physical home switch for TMC2209 requires different jumper settings on the PCB
 // Please refer to documentation PDF for wiring and other options
 
@@ -188,7 +188,7 @@
 
 #if (DRVBRD == PRO2ESP32TMC2209 || DRVBRD == PRO2ESP32TMC2209P)
 #if !defined(USE_STALL_GUARD) && !defined(USE_PHYSICAL_SWITCH)
-#error You must define either USE_STALL_GUARD or USE_PHYSICAL_SWITCH when using a board with TMC2209 driver
+#error You must define either USE_STALL_GUARD or USE_PHYSICAL_SWITCH when using a hpsw with TMC2209 driver
 #endif
 #endif
 

--- a/src/myFP2ESP/generalDefinitions.cpp
+++ b/src/myFP2ESP/generalDefinitions.cpp
@@ -4,7 +4,7 @@
 // (c) Copyright Holger M, 2019-2021. All Rights Reserved.
 // ======================================================================
 
-const char* programVersion            = "226";
+const char* programVersion            = "228";
 const char* ProgramAuthor             = "(c) R BROWN 2020";
 
 const char* MANAGEMENTURLNOTFOUNDSTR  = "<html><head><title>Management server></title></head><body><p>URL was not found</p><p><form action=\"/\" method=\"GET\"><input type=\"submit\" value=\"HOME\"></form></p></body></html>";

--- a/src/myFP2ESP/myBoards.h
+++ b/src/myFP2ESP/myBoards.h
@@ -35,11 +35,10 @@ class DriverBoard
     void initmove(bool, unsigned long);           // prepare to move
     void movemotor(byte, bool);                   // move the motor
     void halt(void);                              // halt the motor
-    bool init_homepositionswitch(void);           // initialize home position switch
+    bool init_hpsw(void);                         // initialize home position switch
     void init_tmc2209(void);
     void init_tmc2225(void);
-    bool hpsw_alert(void);                        // check for HPSW
-    bool checkStall(void);                        // check for TMC2209 stall guard
+    bool hpsw_alert(void);                        // check for HPSW, and for TMC2209 stall guard or physical switch
     void end_move(void);                          // end a move
 
     // getter
@@ -71,7 +70,7 @@ class DriverBoard
     unsigned long focuserposition;                  // current focuser position
     int           inputPins[4];                     // input pins for driving stepper boards
     unsigned int  clock_frequency;                  // clock frequency used to generate 2us delay for ESP32 160Mhz/240Mhz
-    int boardnum;                                   // get the board number from mySetupData
+    int  boardnum;                                  // get the board number from mySetupData
 };
 
 #endif

--- a/src/myFP2ESP/myFP2ESP.ino
+++ b/src/myFP2ESP/myFP2ESP.ino
@@ -1,5 +1,5 @@
 // ======================================================================
-// myFP2ESP myp2esp.ino FIRMWARE OFFICIAL RELEASE 227 [22-June-2021]
+// myFP2ESP myp2esp.ino FIRMWARE OFFICIAL RELEASE 228 [23-June-2021]
 // (c) Copyright Robert Brown 2014-2021. All Rights Reserved.
 // (c) Copyright Holger M, 2019-2021. All Rights Reserved.
 // (c) Copyright Pieter P - OTA code and SPIFFs file handling/upload based on examples
@@ -1761,18 +1761,23 @@ void loop()
           }
           if ( mySetupData->get_brdnumber() == PRO2ESP32TMC2209 || mySetupData->get_brdnumber() == PRO2ESP32TMC2209P )
           {
-            // stall guard in effect - there is no need to find and set position. there is no real backlash
-            // finally,.... the rock has come..... home.
+#if defined(USE_STALL_GUARD)
+            // are home and no need to handle set position, simple
             DebugPrintln("Stall Guard: Pos = 0");
             TimeStampDelayAfterMove = millis();
             MainStateMachine = State_DelayAfterMove;
+#else
+            // not stall guard must be physical switch then we should jump to set home position
+            DebugPrintln("go SetHomePosition");
+            MainStateMachine = State_SetHomePosition;
+#endif // #if defined(USE_STALL_GUARD)
           }
-          else
+          else // not a tmc2209 board
           {
             // we should jump to
             DebugPrintln("go SetHomePosition");
             MainStateMachine = State_SetHomePosition;
-          }
+          } // if ( mySetupData->get_brdnumber() == PRO2ESP32TMC2209 || mySetupData->get_brdnumber() == PRO2ESP32TMC2209P )
         } // if (driverboard->hpsw_alert() )
 
         // if the update position on display when moving is enabled, then update the display


### PR DESCRIPTION
Implement Physical Switch and Stall Guard options for a Home Position Switch for the TMC2209 board

Revise some of the HPSW code in myBoards.cpp to ensure consistent useage and naming across boards. This is because stall guard returns states that are opposite to those states for the physical home position switch.

Merged 228 into Master
